### PR TITLE
fix: 🐛 server side check for innovation submission

### DIFF
--- a/__external__/services/src/errors/index.ts
+++ b/__external__/services/src/errors/index.ts
@@ -109,3 +109,10 @@ export class InvalidAPIKey extends Error {
     this.name = "InvalidAPIKey";
   }
 }
+
+export class InvalidSectionStateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidSectionStateError";
+  }
+}

--- a/__external__/services/src/services/Innovation.service.ts
+++ b/__external__/services/src/services/Innovation.service.ts
@@ -52,7 +52,6 @@ import {
   InnovatorInnovationSummary,
 } from "../models/InnovationSummaryResult";
 import { BaseService } from "./Base.service";
-import { InnovationSectionService } from "./InnovationSection.service";
 import { LoggerService } from "./Logger.service";
 import { NotificationService } from "./Notification.service";
 import { UserService } from "./User.service";

--- a/__external__/services/src/services/Innovation.service.ts
+++ b/__external__/services/src/services/Innovation.service.ts
@@ -3,6 +3,9 @@ import {
   Innovation,
   InnovationAction,
   InnovationActionStatus,
+  InnovationSection,
+  InnovationSectionCatalogue,
+  InnovationSectionStatus,
   InnovationStatus,
   InnovationSupport,
   InnovationSupportStatus,
@@ -15,6 +18,7 @@ import {
 import {
   InnovationNotFoundError,
   InvalidParamsError,
+  InvalidSectionStateError,
   InvalidUserRoleError,
   MissingUserOrganisationError,
 } from "@services/errors";
@@ -27,6 +31,7 @@ import {
   InnovationListModel,
   InnovationViewModel,
 } from "@services/models/InnovationListModel";
+import { InnovationSectionModel } from "@services/models/InnovationSectionModel";
 import { ProfileModel } from "@services/models/ProfileModel";
 import { ProfileSlimModel } from "@services/models/ProfileSlimModel";
 import { RequestUser } from "@services/models/RequestUser";
@@ -47,6 +52,7 @@ import {
   InnovatorInnovationSummary,
 } from "../models/InnovationSummaryResult";
 import { BaseService } from "./Base.service";
+import { InnovationSectionService } from "./InnovationSection.service";
 import { LoggerService } from "./Logger.service";
 import { NotificationService } from "./Notification.service";
 import { UserService } from "./User.service";
@@ -57,6 +63,7 @@ export class InnovationService extends BaseService<Innovation> {
   private readonly supportRepo: Repository<InnovationSupport>;
   private readonly notificationService: NotificationService;
   private readonly logService: LoggerService;
+
   constructor(connectionName?: string) {
     super(Innovation, connectionName);
     this.connection = getConnection(connectionName);
@@ -605,6 +612,13 @@ export class InnovationService extends BaseService<Innovation> {
     };
   }
 
+  async hasIncompleteSections(sections) {
+    const innovationSections = this.getInnovationSectionsMetadata(sections);
+    return innovationSections.some(
+      (x) => x.status !== InnovationSectionStatus.SUBMITTED
+    );
+  }
+
   async submitInnovation(requestUser: RequestUser, id: string) {
     if (!id || !requestUser || !checkIfValidUUID(id)) {
       throw new InvalidParamsError(
@@ -624,6 +638,15 @@ export class InnovationService extends BaseService<Innovation> {
     );
     if (!innovation) {
       throw new InnovationNotFoundError("Innovation not found for the user.");
+    }
+
+    const sections = await innovation.sections;
+    const canSubmit = !(await this.hasIncompleteSections(sections));
+
+    if (!canSubmit) {
+      throw new InvalidSectionStateError(
+        "Cannot submit the innovation for assessment with incomplete sections."
+      );
     }
 
     await this.repository.update(innovation.id, {
@@ -1030,5 +1053,47 @@ export class InnovationService extends BaseService<Innovation> {
       }
     */
     return supportMap;
+  }
+
+  private getInnovationSectionsMetadata(
+    sections: InnovationSection[]
+  ): InnovationSectionModel[] {
+    const innovationSections: InnovationSectionModel[] = [];
+
+    for (const key in InnovationSectionCatalogue) {
+      const section = sections.find((sec) => sec.section === key);
+      innovationSections.push(this.getInnovationSectionMetadata(key, section));
+    }
+
+    return innovationSections;
+  }
+
+  private getInnovationSectionMetadata(
+    key: string,
+    section?: InnovationSection
+  ): InnovationSectionModel {
+    let result: InnovationSectionModel;
+
+    if (section) {
+      result = {
+        id: section.id,
+        section: section.section,
+        status: section.status,
+        updatedAt: section.updatedAt,
+        submittedAt: section.submittedAt,
+        actionStatus: null,
+      };
+    } else {
+      result = {
+        id: null,
+        section: InnovationSectionCatalogue[key],
+        status: InnovationSectionStatus.NOT_STARTED,
+        updatedAt: null,
+        submittedAt: null,
+        actionStatus: null,
+      };
+    }
+
+    return result;
   }
 }


### PR DESCRIPTION
Implements server side validation to prevent cases where a malicious user could manipulate the client and submit an innovation for assessment with incomplete or non existent innovation record sections