### PR TITLE
feat: 🎸 adds suggested organisation units only filter

### DIFF
--- a/__external__/services/src/services/Innovation.service.ts
+++ b/__external__/services/src/services/Innovation.service.ts
@@ -151,6 +151,7 @@ export class InnovationService extends BaseService<Innovation> {
     requestUser: RequestUser,
     supportStatus: InnovationSupportStatus,
     assignedToMe: boolean,
+    suggestedOnly: boolean,
     skip: number,
     take: number,
     order?: { [key: string]: string }
@@ -199,6 +200,17 @@ export class InnovationService extends BaseService<Innovation> {
       if (supportStatus === InnovationSupportStatus.UNASSIGNED) {
         filterOptions.relations = ["organisationShares", "assessments"];
         filterOptions.where += ` and NOT EXISTS(SELECT 1 FROM innovation_support tmp WHERE tmp.innovation_id = Innovation.id and deleted_at is null and tmp.organisation_unit_id = '${organisationUnit.id}')`;
+
+        if (suggestedOnly) {
+          filterOptions.where += `
+            and EXISTS (
+              SELECT 1 FROM innovation_assessment A
+              INNER JOIN innovation_assessment_organisation_unit B
+              ON A.ID = B.innovation_assessment_id
+              WHERE B.organisation_unit_id = '${organisationUnit.id}'
+            )
+          `;
+        }
       } else {
         filterOptions.relations = [
           "organisationShares",

--- a/__tests__/accessorsGetAllInnovations/persistence.spec.ts
+++ b/__tests__/accessorsGetAllInnovations/persistence.spec.ts
@@ -36,6 +36,7 @@ describe("[accessorsGetAllInnovations] Persistence suite", () => {
         ctx as CustomContext,
         "ENGAGING",
         true,
+        false,
         0,
         10
       );

--- a/accessorsGetAllInnovations/index.ts
+++ b/accessorsGetAllInnovations/index.ts
@@ -36,6 +36,10 @@ class AccessorsGetAllInnovations {
     const assignedToMe = query.assignedToMe
       ? query.assignedToMe.toLocaleLowerCase() === "true"
       : false;
+    const suggestedOnly = query.suggestedOnly
+      ? query.suggestedOnly.toLocaleLowerCase() === "true"
+      : false;
+
     const skip = parseInt(query.skip);
     const take = parseInt(query.take);
 
@@ -50,6 +54,7 @@ class AccessorsGetAllInnovations {
         context,
         supportStatus,
         assignedToMe,
+        suggestedOnly,
         skip,
         take,
         order

--- a/accessorsGetAllInnovations/persistence/index.ts
+++ b/accessorsGetAllInnovations/persistence/index.ts
@@ -4,6 +4,7 @@ export const findAllInnovationsByAccessor = async (
   ctx: CustomContext,
   supportStatus: string,
   assignedToMe: boolean,
+  suggestedOnly: boolean,
   skip: number,
   take: number,
   order?: { [key: string]: string }
@@ -12,6 +13,7 @@ export const findAllInnovationsByAccessor = async (
     ctx.auth.requestUser,
     supportStatus as InnovationSupportStatus,
     assignedToMe,
+    suggestedOnly,
     skip,
     take,
     order

--- a/accessorsGetAllInnovations/validation/index.ts
+++ b/accessorsGetAllInnovations/validation/index.ts
@@ -5,6 +5,7 @@ const querySchema = Joi.object({
   skip: Joi.number().required(),
   supportStatus: Joi.string().required(),
   assignedToMe: Joi.boolean().optional(),
+  suggestedOnly: Joi.boolean().optional(),
 }).unknown(true);
 
 export const ValidateQueryParams = (data: object): any => {


### PR DESCRIPTION
From the QAcessor perspective, when reviewing innovations there is now a Suggested to my organisation unit filter. This filter will only be available when the `Unassigned` is active. 

If an innovation was suggested, by either the Needs Assessment team or another Qualifying Accessor, to have an organisation unit engaging with it then the qualifying accessors of that unit will have this innovation listed on the results.