### PR TITLE
NHSAAC 75795

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1196,14 +1196,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/bson": {
-      "version": "4.0.3",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/@types/bson/-/bson-4.0.3.tgz",
-      "integrity": "sha1-MIidL/3mJiq744ZZNkxjFFSZn78=",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/faker": {
       "version": "5.5.5",
       "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.5.tgz",
@@ -1271,15 +1263,6 @@
       "integrity": "sha1-AMr11zfkrMEA9bmBUsY17avbANc=",
       "dev": true
     },
-    "@types/mongodb": {
-      "version": "3.6.10",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/@types/mongodb/-/mongodb-3.6.10.tgz",
-      "integrity": "sha1-gMzqq+7J9GDltGhE6Tjo66dPkmY=",
-      "requires": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "15.12.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
@@ -1334,6 +1317,20 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
+    },
+    "@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
+      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -1565,9 +1562,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -2270,20 +2267,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "bl": {
-      "version": "2.2.1",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha1-jBGntzBlXF1WiYzchxIk9A/ZAdU=",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2309,16 +2292,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha1-NAqkaUDX24eHSFZ8XeokpI3fNxc=",
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
+      "integrity": "sha512-59IqHJV5VGdcJZ+GZ2hU5n4Kv3YiASzW6Xk5g9tf5a/MAzGeFwgGWU39fVzNIOVcgB3+Gp+kiQu0HEfTVU/3VQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001264",
+        "electron-to-chromium": "^1.3.857",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.77",
+        "picocolors": "^0.2.1"
       }
     },
     "bs-logger": {
@@ -2340,9 +2323,21 @@
       }
     },
     "bson": {
-      "version": "1.1.6",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha1-+4Gb6aYM1nfghTruTKcSp4XWYYo="
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.5.3.tgz",
+      "integrity": "sha512-qVX7LX79Mtj7B3NPLzCfBiCP6RAsjiV8N63DjlaVVpZW+PFoDTxQ4SeDbSpcqgE6mXksM5CAwZnXxxxn/XwC0g==",
+      "requires": {
+        "buffer": "^5.6.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -2729,12 +2724,6 @@
       "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
     },
-    "colorette": {
-      "version": "1.2.2",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha1-y8x51emcrqLb8Q6zom/Ys+as+pQ=",
-      "dev": true
-    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2978,9 +2967,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "denque": {
-      "version": "1.5.0",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/denque/-/denque-1.5.0.tgz",
-      "integrity": "sha1-dz3gaG/y2Owv+SkUMWpHtzscc94="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -3086,9 +3075,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.698",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/electron-to-chromium/-/electron-to-chromium-1.3.698.tgz",
-      "integrity": "sha1-XegTlg8jWBomhxigBYaD3/oV0iE=",
+      "version": "1.3.861",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.861.tgz",
+      "integrity": "sha512-GZyflmpMnZRdZ1e2yAyvuFwz1MPSVQelwHX4TJZyXypB8NcxdPvPNwy5lOTxnlkrK13EiQzyTPugRSnj6cBgKg==",
       "dev": true
     },
     "emitter-listener": {
@@ -4200,9 +4189,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha1-dTm9S8Hg4KiVgVouAmJCCxKFhIg=",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -4655,7 +4644,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -5569,8 +5559,8 @@
     },
     "kareem": {
       "version": "2.3.2",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/kareem/-/kareem-2.3.2.tgz",
-      "integrity": "sha1-eMRQiJSYW404oNwV4ajhEHjyypM="
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
+      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -5757,8 +5747,8 @@
     },
     "memory-pager": {
       "version": "1.5.0",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha1-2HUWVdItOEaCdByXLyw9bfo+ZrU=",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "optional": true
     },
     "merge-stream": {
@@ -5849,77 +5839,73 @@
       "dev": true
     },
     "mongodb": {
-      "version": "3.6.5",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/mongodb/-/mongodb-3.6.5.tgz",
-      "integrity": "sha1-wn14b9TTyD3BkwJINwfRKp0q7l8=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.2.tgz",
+      "integrity": "sha512-pHCKDoOy1h6mVurziJmXmTMPatYWOx8pbnyFgSgshja9Y36Q+caHUzTDY6rrIy9HCSrjnbXmx3pCtvNZHmR8xg==",
       "requires": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "bson": "^4.5.2",
+        "denque": "^2.0.1",
+        "mongodb-connection-string-url": "^2.0.0",
+        "saslprep": "^1.0.3"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.1.0.tgz",
+      "integrity": "sha512-Qf9Zw7KGiRljWvMrrUFDdVqo46KIEiDuCzvEN97rh/PcKzk2bd6n9KuzEwBwW9xo5glwx69y1mI6s+jFUD/aIQ==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^9.1.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "whatwg-url": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
+          "integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
+          "requires": {
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
       }
     },
     "mongoose": {
-      "version": "5.12.2",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/mongoose/-/mongoose-5.12.2.tgz",
-      "integrity": "sha1-MnRjDfuajmPb2gxucST9R1Yjxv8=",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.0.9.tgz",
+      "integrity": "sha512-j9wcL8sltyIPBzMv785HFuGOdO8a5b70HX+e1q5QOogJxFofEXQoCcuurGlFSOe6j8M25qxHLzeVeKVcITeviQ==",
       "requires": {
-        "@types/mongodb": "^3.5.27",
-        "bson": "^1.1.4",
+        "bson": "^4.2.2",
         "kareem": "2.3.2",
-        "mongodb": "3.6.5",
-        "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.8.3",
-        "mquery": "3.2.4",
+        "mongodb": "4.1.2",
+        "mpath": "0.8.4",
+        "mquery": "4.0.0",
         "ms": "2.1.2",
         "regexp-clone": "1.0.0",
-        "safe-buffer": "5.2.1",
-        "sift": "7.0.1",
+        "sift": "13.5.2",
         "sliced": "1.0.1"
       }
     },
-    "mongoose-legacy-pluralize": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-      "integrity": "sha1-O6n5H6UHtRhtOZ+0CFS/8Y+1Y+Q="
-    },
     "mpath": {
-      "version": "0.8.3",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/mpath/-/mpath-0.8.3.tgz",
-      "integrity": "sha1-gorA0Yf39CZ0g510khlwl5q73Y8="
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
+      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
     },
     "mquery": {
-      "version": "3.2.4",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/mquery/-/mquery-3.2.4.tgz",
-      "integrity": "sha1-nFwuKF6mxvIGc/NSiXPJnuGqoaA=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.0.tgz",
+      "integrity": "sha512-nGjm89lHja+T/b8cybAby6H0YgA4qYC/lx6UlwvHGqvTq8bDaNeCwl1sY8uRELrNbVWJzIihxVd+vphGGn1vBw==",
       "requires": {
-        "bluebird": "3.5.1",
-        "debug": "3.1.0",
+        "debug": "4.x",
         "regexp-clone": "^1.0.0",
-        "safe-buffer": "5.1.2",
         "sliced": "1.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
-        }
       }
     },
     "ms": {
@@ -6056,9 +6042,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.71",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/node-releases/-/node-releases-1.1.71.tgz",
-      "integrity": "sha1-yxM0sXmJaxyJ7P3UtyX7e738fbs=",
+      "version": "1.1.77",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+      "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
       "dev": true
     },
     "normalize-package-data": {
@@ -6384,9 +6370,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {
@@ -6399,6 +6385,12 @@
       "version": "2.1.0",
       "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
     },
     "picomatch": {
       "version": "2.2.2",
@@ -6504,7 +6496,9 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+      "dev": true,
+      "optional": true
     },
     "progress": {
       "version": "2.0.3",
@@ -6615,6 +6609,8 @@
       "version": "2.3.7",
       "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+      "dev": true,
+      "optional": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -6628,7 +6624,9 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6790,8 +6788,8 @@
     },
     "regexp-clone": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/regexp-clone/-/regexp-clone-1.0.0.tgz",
-      "integrity": "sha1-Ii25Z2IydwViYLmSYmNUoEzpv2M="
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
     },
     "regexpp": {
       "version": "3.1.0",
@@ -6928,15 +6926,6 @@
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
-      "requires": {
-        "resolve-from": "^2.0.0",
-        "semver": "^5.1.0"
-      }
-    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/resolve/-/resolve-1.20.0.tgz",
@@ -6963,11 +6952,6 @@
           "dev": true
         }
       }
-    },
-    "resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -7490,8 +7474,8 @@
     },
     "saslprep": {
       "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha1-TAL5RrVs9UKX40e6EJPnrKxM8iY=",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
@@ -7593,9 +7577,9 @@
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "sift": {
-      "version": "7.0.1",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/sift/-/sift-7.0.1.tgz",
-      "integrity": "sha1-R9YsULFZ0xbxNy+LU/nBDNIaSwg="
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
+      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -7628,7 +7612,7 @@
     },
     "sliced": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/sliced/-/sliced-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
     "snapdragon": {
@@ -7796,7 +7780,7 @@
     },
     "sparse-bitfield": {
       "version": "3.0.3",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
       "optional": true,
       "requires": {
@@ -8240,9 +8224,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
@@ -8726,8 +8710,7 @@
     "webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-      "integrity": "sha1-kRG01+qArNQPUnDWZmIa+ni2lRQ=",
-      "dev": true
+      "integrity": "sha1-kRG01+qArNQPUnDWZmIa+ni2lRQ="
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -8835,9 +8818,9 @@
       }
     },
     "ws": {
-      "version": "7.4.4",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/ws/-/ws-7.4.4.tgz",
-      "integrity": "sha1-ODvJdCyyAikskHfOq29gR7F/LVk=",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
       "dev": true
     },
     "xml-name-validator": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1746,11 +1746,11 @@
       "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk="
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha1-IlY0gZYvTWvemnbVFu8OXTwJsrg=",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "babel-cli": {
@@ -2417,9 +2417,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001204",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
-      "integrity": "sha1-JWyFcJo0jsTRdehHo7UVxm558qo=",
+      "version": "1.0.30001265",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+      "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
       "dev": true
     },
     "capture-exit": {
@@ -3856,9 +3856,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.3",
-      "resolved": "https://pkgs.dev.azure.com/NHSE-I-AAC/InnovationService/_packaging/NHS-I-AAC-NPM/npm/registry/follow-redirects/-/follow-redirects-1.13.3.tgz",
-      "integrity": "sha1-5VmK1QF0wbxOhyMB6CrCzZf5Amc="
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
+      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -8534,9 +8534,9 @@
       }
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://pkgs.dev.azure.com/NHSiDev/InnovatorService/_packaging/InnovatorServiceFeed/npm/registry/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "jsonwebtoken": "^8.5.1",
     "jwt-decode": "^3.1.2",
     "memory-cache": "^0.2.0",
-    "mongoose": "^5.12.0",
+    "mongoose": "^6.0.9",
     "mssql": "^6.3.1",
     "notifications-node-client": "^5.1.0",
     "tslib": "^1.9.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@azure/cosmos": "^3.10.3",
     "@azure/storage-blob": "^12.5.0",
     "applicationinsights": "^2.0.0",
-    "axios": "^0.21.1",
+    "axios": "^0.21.4",
     "class-transformer": "^0.4.0",
     "joi": "^17.4.0",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
Fixes most npm audit vulnerabilities
Updates Mongoose to 6.0.9
Updates Axios to 0.21.4

Leaves behind 10 critical and 12 high vulnerability reports. All of which target `lodash` being used by `babel-cli` and `jest`.
Since none of these are ever deployed or publicly accessible, we are leaving this unfixed moslty because of Jest that got large breaking changes that would force us to refactor 100% of our unit tests. Early experiences have shown that this is not a simple find and replace job.

Might be worth to create a task that accomodates a large update to the Unit Tests, but I assess this is not prioritary