### PR TITLE
AllowUserType decorator now checks if user is locked before anything.

### DIFF
--- a/utils/decorators/index.ts
+++ b/utils/decorators/index.ts
@@ -301,6 +301,13 @@ export function AllowedUserType(...type: UserType[]) {
         where: { externalId: oid },
       });
 
+      // if user exists and lockedAt property is not null or undefined means the user is locked.
+      // throw a Unauthorized error
+      if (user && user.lockedAt) {
+        context.res = Responsify.Unauthorized({ locked: true });
+        return;
+      }
+      
       /// TODO:  REMOVE AFTER FTSI REFACTOR
       if (!user) {
         context.auth.requestUser = {


### PR DESCRIPTION
# Context
Up until now, the way we prevent `locked` users from signing in is totally reliant on the identity provider. Locking a user is done through marking its account as `Disabled` on Azure B2C.
This works well because when we Lock users, we do it in a synchronous way, that is, we lock it on the Innovation Service database and on the Identity Provider within a Transaction which rolls back the operation if one of these fails.

With the advent of push-pull messaging patterns in the Innovation Service, we decided to make locking users on Azure B2C asynchronous. Eventually the accounts are disabled and, therefore, the client does not have to wait for this operation to complete.

This creates a situation where in the meantime, before the user is disabled on the Identity Provider or if the act of disabling the user account fails, the user can still sign in and carry on with his normal activity because we never check on the back-end if the user is locked or not.

This is what this PR is set to fix.

# Solution

We rely on a `RequestUser` object to validate whether the signed in user is allowed to call a given back-end endpoint.
This object is created inside the `AllowedUserType` decorator and it is attached to the `context.auth` object, which is then passed through the execution flow of the endpoint.
Because we trust 100% on the Identity Provider, when the `User` object is fetched we never check if the `lockedAt` property is empty. Being empty (null or undefined) denotes that the user is **NOT** locked. This is the default state of the `lockedAt` property

To fix this, as soon as we fetch the `User` from the Innovation Service database, we check the `lockedAt` property and act accordingly whether it is empty or not. If it not empty, we respond back to the client with an HTTP Status Code  `401 - Unauthorized` with a body with an object as follows:

```
{
   locked: true
}
```
This way, the client knows exactly why it was unable to carry out the operation and prompt the user accordingly.
