### PR TITLE
Feat/idp lock users queue

### DIFF
--- a/__external__/services/src/config/queue/handlers/index.ts
+++ b/__external__/services/src/config/queue/handlers/index.ts
@@ -9,7 +9,9 @@ export async function lockUserIdentityQueueHandler(
 ): Promise<{ success: boolean; extra?: unknown }> {
   const adminService = queueContext.services.AdminService;
 
-  const result = await adminService.lockUsers(
+  // use method that only locks user on the IdP level.
+  // removes redundant database lock (already occured)
+  const result = await adminService.lockUsersIdP(
     context.requestUser,
     context.identityId
   );

--- a/__external__/services/src/helpers/index.ts
+++ b/__external__/services/src/helpers/index.ts
@@ -278,24 +278,3 @@ export function checkIfValidUUID(str: string): boolean {
 
   return regexExp.test(str);
 }
-
-export async function retryCreateQueueMessage<T extends QueueMessageEnum>(
-  fn:(messageType: T, data: QueueContextType<T>) => Promise<boolean>,
-  args: Parameters<(messageType: T, data: QueueContextType<T>) => Promise<boolean>>,
-  maxRetries: number,
-  retryCount = 1,
-): Promise<boolean> {
-
-  const currentRetry = typeof retryCount === "number" ? retryCount: 1;
-  try {
-    return await fn(args[0], args[1]); 
-  } catch (error) {
-    if (currentRetry > maxRetries) {
-      throw error;
-    }
-
-    setTimeout(() => {
-      return retryCreateQueueMessage(fn, args, maxRetries, retryCount++);  
-    }, 100);
-  }
-}

--- a/__external__/services/src/helpers/index.ts
+++ b/__external__/services/src/helpers/index.ts
@@ -280,15 +280,15 @@ export function checkIfValidUUID(str: string): boolean {
 }
 
 export async function retryCreateQueueMessage<T extends QueueMessageEnum>(
-  fn: <Q extends QueueMessageEnum>(messageType: Q, data: QueueContextType<T>) => Promise<boolean>,
-  args: Parameters<<Q extends QueueMessageEnum>(messageType: Q, data: QueueContextType<T>) => Promise<boolean>>,
+  fn:(messageType: T, data: QueueContextType<T>) => Promise<boolean>,
+  args: Parameters<(messageType: T, data: QueueContextType<T>) => Promise<boolean>>,
   maxRetries: number,
   retryCount = 1,
 ): Promise<boolean> {
 
   const currentRetry = typeof retryCount === "number" ? retryCount: 1;
   try {
-    return await fn<typeof args[0]>(args[0], args[1]); 
+    return await fn(args[0], args[1]); 
   } catch (error) {
     if (currentRetry > maxRetries) {
       throw error;

--- a/__external__/services/src/services/Admin.service.ts
+++ b/__external__/services/src/services/Admin.service.ts
@@ -50,7 +50,6 @@ import {
   authenticateWitGraphAPI,
   deleteB2CAccount,
   getUserFromB2C,
-  retryCreateQueueMessage,
 } from "../helpers";
 import { InnovationSupportService } from "./InnovationSupport.service";
 import { LoggerService } from "./Logger.service";

--- a/__external__/services/src/services/Admin.service.ts
+++ b/__external__/services/src/services/Admin.service.ts
@@ -792,31 +792,14 @@ export class AdminService {
     // This is executed outside the transaction.
     // If a message fails to be delivered, we don't want to roll back.
 
+    // FIRE AND FORGET
+
     for (const user of usersToLock) {
-      try {
-        // retries 3 times before giving up and finally throwing 
-        await retryCreateQueueMessage<QueueMessageEnum.LOCK_USER>(
-          this.queueService.createQueueMessage,
-          [
-            QueueMessageEnum.LOCK_USER,
-            { requestUser, identityId: user.externalId },
-          ],
-          3
-        );
-
-        // await this.queueService.createQueueMessage<QueueMessageEnum.LOCK_USER>(
-        //   QueueMessageEnum.LOCK_USER,
-        //   { requestUser, identityId: user.externalId }
-        // );
-
-      } catch (error) {
-        this.logService.error(
-          `Correlation: ${correlationId}: [IDP Lock] failed to send message to lock user queue for user ${user.externalId}`,
-          {
-            error,
-          }
-        );
-      }
+      this.queueService.createQueueMessage<QueueMessageEnum.LOCK_USER>(
+        QueueMessageEnum.LOCK_USER,
+        { requestUser, identityId: user.externalId },
+        correlationId,
+      );
     }
 
     return result;

--- a/__external__/services/src/services/Admin.service.ts
+++ b/__external__/services/src/services/Admin.service.ts
@@ -681,6 +681,8 @@ export class AdminService {
 
         // Asynchronously lock users at the IdP using queue messages (push pull pattern)
         for (const user of usersToLock) {
+          // The handler of this queue should generate notifications for the locked users
+          // NOT IMPLEMENTED NOTIFICATIONS
           await this.queueService.createQueueMessage<QueueMessageEnum.LOCK_USER>(
             QueueMessageEnum.LOCK_USER,
             { requestUser, identityId: user.externalId }

--- a/__external__/services/src/services/Queue.service.ts
+++ b/__external__/services/src/services/Queue.service.ts
@@ -30,6 +30,8 @@ export const STORAGE_QUEUE_CONFIG = Object.freeze({
   storageQueueName: process.env.AZURE_STORAGE_QUEUE_NAME || "",
 });
 
+type CreateMessageType<T extends QueueMessageEnum> = (messageType: T, data: QueueContextType<T>) => Promise<boolean>;
+
 export class QueueService {
   logger: LoggerService;
   queueClient: QueueClient;

--- a/__external__/services/src/services/Queue.service.ts
+++ b/__external__/services/src/services/Queue.service.ts
@@ -30,7 +30,10 @@ export const STORAGE_QUEUE_CONFIG = Object.freeze({
   storageQueueName: process.env.AZURE_STORAGE_QUEUE_NAME || "",
 });
 
-type CreateMessageType<T extends QueueMessageEnum> = (messageType: T, data: QueueContextType<T>) => Promise<boolean>;
+type CreateMessageType<T extends QueueMessageEnum> = (
+  messageType: T,
+  data: QueueContextType<T>
+) => Promise<boolean>;
 
 export class QueueService {
   logger: LoggerService;
@@ -43,9 +46,12 @@ export class QueueService {
 
   async createQueueMessage<T extends QueueMessageEnum>(
     messageType: T,
-    data: QueueContextType<T>
+    data: QueueContextType<T>,
+    correlationId: string,
+    maxRetries: number = 3,
+    retryCount?: number
   ): Promise<boolean> {
-    const correlationId = uuid();
+    const currentRetry = retryCount ?? 1;
 
     const { queue } = this.getQueueConfig<T>(messageType);
 
@@ -61,9 +67,27 @@ export class QueueService {
 
     const payload = Buffer.from(JSON.stringify(message)).toString("base64");
 
-    const response = await this.queueClient.sendMessage(payload);
+    try {
+      const response = await this.queueClient.sendMessage(payload);
+      return response._response.status === 201;
+    } catch (error) {
+      if (currentRetry > maxRetries) {
+        this.logger.error(
+          `Correlation: ${correlationId}: [IDP Lock] failed to send message to lock user queue for user ${data.identityId}`,
+          {
+            error,
+          }
+        );
+      }
 
-    return response._response.status === 201;
+      this.createQueueMessage(
+        messageType,
+        data,
+        correlationId,
+        maxRetries,
+        currentRetry + 1
+      );
+    }
   }
 
   async handleMessage<T extends QueueMessageEnum>(

--- a/adminsInactivateUnits/index.ts
+++ b/adminsInactivateUnits/index.ts
@@ -16,7 +16,7 @@ import { CustomContext, Severity } from "../utils/types";
 import * as persistence from "./persistence";
 import * as validation from "./validation";
 
-class AdminsCreateUser {
+class AdminsInactivateUnits {
   @AppInsights()
   @SQLConnector()
   @Validator(validation.ValidatePayload, "body", "Invalid Payload")
@@ -45,4 +45,4 @@ class AdminsCreateUser {
   }
 }
 
-export default AdminsCreateUser.httpTrigger;
+export default AdminsInactivateUnits.httpTrigger;


### PR DESCRIPTION
# Background
Locking users was done synchronously one by one.
When locking units, arose the need to lock multiple users on the Identity Provider and that made the whole process extremely low performance.

# Solution and Caveats
Locking users on the IdP, in the context of Unit inactivation, happens using message queues on the background.

The caveat, or not so much, is that the background worker is still calling the legacy lock user method, which does generate notifications as before, but...does take a long time to execute. Summing up, it works, the client doesn't have to wait for the locking on the IdP to occur, but it still is low performance. On the bright side, this is something that is going to be discontinued when the Monorepo comes to live.
